### PR TITLE
re-work cmake configuration for proper build type support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,22 @@
 cmake_minimum_required(VERSION 3.9)
-project(SuperFWGPUKernels CUDA CXX)
+project(SrgemmCudaKernels CUDA CXX)
 
-# RELEASE config by default:
-if (NOT CMAKE_BUILD_TYPE)
+string(TOUPPER "${CMAKE_BUILD_TYPE}" uppercase_CMAKE_BUILD_TYPE)
+
+# RELEASE config by default ifnone is provided:
+if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "RELEASE")
   set(BUILD_TYPE_INFERRED_RELEASE TRUE)
-endif ()
+elseif()
+  # otherwise, first convert build type string to uppercase, and then compare
+  if(NOT uppercase_CMAKE_BUILD_TYPE MATCHES "^(DEBUG|RELEASE|RELWITHDEBINFO)$")
+    message(FATAL_ERROR "Invalid value for CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
+  endif()
+  set(BUILD_TYPE_INFERRED_RELEASE FALSE)
+endif()
+
+# always dump compiler invocation commands to compile_commands.json
+set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 
 # Switches for testing, benchmarks or static lib builds
 option(FWGPU_TEST   "FWGPU_TEST"   ON)
@@ -13,10 +24,10 @@ option(FWGPU_BENCH  "FWGPU_BENCH"  ON)
 option(FWGPU_STATIC "FWGPU_STATIC" ON)
 
 # static or dynamic lib build targets
-if (FWGPU_STATIC)
+if(FWGPU_STATIC)
   set(FWGPU_LIB_NAME fwgpu_static)
   set(FWGPU_LIB_TYPE STATIC)
-else ()
+else()
   set(FWGPU_LIB_NAME fwgpu)
   set(FWGPU_LIB_TYPE SHARED)
 endif()
@@ -24,30 +35,33 @@ endif()
 # CUDA native compiler (nvcc) only supports upto C++14 for now
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Wall -fno-exceptions -DNDEBUG")
-set(CMAKE_CXX_FLAGS_DEBUG   "-O0 -Wall -Wextra -Wno-unused-parameter -fno-exceptions -DDEBUG -g")
+set(CMAKE_CXX_FLAGS_DEBUG   "-O0 -g -DDEBUGp -Wall -Wextra -Wno-unused-parameter -fno-exceptions")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUGp -Wall -fno-exceptions")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g -DNDEBUG -fno-omit-frame-pointerp -Wall -fno-exceptions")
+# set(CMAKE_CXX_CLANG_TIDY clang-tidy -checks='bugprone-*,cert-*,clang-analyzer-core*,misc-*,performance-*')
 
 # CUDA build flags
 find_package(CUDA REQUIRED)
-if (CUDA_FOUND)
-  if (NOT CMAKE_CUDA_FLAGS)
+if(CUDA_FOUND)
+  if(NOT CMAKE_CUDA_FLAGS)
     cuda_select_nvcc_arch_flags(CUDA_ARCH_FLAGS Auto)
   endif()
-  set(CUDA_NVCC_FLAGS_RELEASE "-O3 --expt-relaxed-constexpr -DNDEBUG ${CMAKE_CUDA_FLAGS} ${CUDA_ARCH_FLAGS}")
-  set(CUDA_NVCC_FLAGS_DEBUG "-O0 --expt-relaxed-constexpr -DDEBUG -g -G ${CMAKE_CUDA_FLAGS} ${CUDA_ARCH_FLAGS}")
+  set(CUDA_NVCC_FLAGS_DEBUG "-O0 -g -G -DDEBUG --expt-relaxed-constexpr ${CMAKE_CUDA_FLAGS} ${CUDA_ARCH_FLAGS}")
+  set(CUDA_NVCC_FLAGS_RELEASE "-O3 -DNDEBUG --expt-relaxed-constexpr ${CMAKE_CUDA_FLAGS} ${CUDA_ARCH_FLAGS}")
+  set(CUDA_NVCC_FLAGS_RELWITHDEBINFO "-O3 -g -G -DNDEBUG --expt-relaxed-constexpr ${CMAKE_CUDA_FLAGS} ${CUDA_ARCH_FLAGS}")
 endif()
 
 # Source directory structure
 include_directories(${PROJECT_SOURCE_DIR}/include ${CUDA_INCLUDE_DIRS})
 
-if (FWGPU_TEST)
+if(FWGPU_TEST)
   enable_testing()
   add_subdirectory(test)
-endif ()
+endif()
 
-if (FWGPU_BENCH)
+if(FWGPU_BENCH)
   add_subdirectory(bench)
-endif ()
+endif()
 
 # fwgpu library configuration
 set(fwgpu_src
@@ -74,25 +88,19 @@ install(DIRECTORY ${FWGPU_LIB_NAME}/include DESTINATION include)
 
 message(STATUS "")
 message(STATUS "BUILD SUMMARY:")
+message(STATUS "  Build type           : ${uppercase_CMAKE_BUILD_TYPE}")
 message(STATUS "  CMAKE_GENERATOR      : ${CMAKE_GENERATOR}")
 message(STATUS "  C++ Compiler         : ${CMAKE_CXX_COMPILER}")
 message(STATUS "  C++ Compiler version : ${CMAKE_CXX_COMPILER_VERSION}")
 message(STATUS "  CUDA Compiler        : ${CMAKE_CUDA_COMPILER}")
 message(STATUS "  CUDA Compiler version: ${CMAKE_CUDA_COMPILER_VERSION}")
-message(STATUS "  Build type           : ${CMAKE_BUILD_TYPE}")
 message(STATUS "  Library name         : ${FWGPU_LIB_NAME}")
 message(STATUS "  Library type         : ${FWGPU_LIB_TYPE}")
 message(STATUS "  Build tests          : ${FWGPU_TEST}")
 message(STATUS "  Build benchmarks     : ${FWGPU_BENCH}")
 message(STATUS "  Found CUDA?          : ${CUDA_FOUND}")
-if("${CMAKE_BUILD_TYPE}" STREQUAL "RELEASE")
-  message(STATUS "  CXX flags            : ${CMAKE_CXX_FLAGS_RELEASE}")
-  message(STATUS "  CUDA flags           : ${CUDA_NVCC_FLAGS_RELEASE}")
-else()
-  message(STATUS "  CXX flags            : ${CMAKE_CXX_FLAGS_DEBUG}")
-  message(STATUS "  CUDA flags           : ${CUDA_NVCC_FLAGS_DEBUG}")
-endif()
+message(STATUS "  CXX flags            : ${CMAKE_CXX_FLAGS_${uppercase_CMAKE_BUILD_TYPE}}")
+message(STATUS "  CUDA flags           : ${CUDA_NVCC_FLAGS_${uppercase_CMAKE_BUILD_TYPE}}")
 if (BUILD_TYPE_INFERRED_RELEASE)
-  message(STATUS "WARNING: No build type provided, defaulted to RELEASE configuration.")
+  message(WARNING "No build type provided, defaulted to RELEASE configuration.")
 endif()
-message(STATUS "")


### PR DESCRIPTION
We now support three build types - debug, release and the new release
with debug info. RelWithDebInfo is intended for profiling runs and
optimized build debugging.

Additionally, incorrect build type names are rejected
instead of silently switching to release. In case no build type is
provided, we still assume release however, with a warning.

project name also been change to better reflect its intent.