### PR TITLE
cmake rework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,10 +73,10 @@ target_link_libraries(
   ${CUDA_CUBLAS_LIBRARIES}
 )
 
-target_include_directories(${FWGPU_LIB_NAME} PUBLIC
-  ${PROJECT_SOURCE_DIR}/include
-  ${PROJECT_SOURCE_DIR}/cutlass/include
-  ${CUDA_INCLUDE_DIRS})
+target_include_directories(${FWGPU_LIB_NAME}
+  PUBLIC ${PROJECT_SOURCE_DIR}/include ${CUDA_INCLUDE_DIRS}
+  PRIVATE ${PROJECT_SOURCE_DIR}/cutlass/include
+)
 
 install(TARGETS ${FWGPU_LIB_NAME} LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
 install(DIRECTORY ${FWGPU_LIB_NAME}/include DESTINATION include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,22 @@
 cmake_minimum_required(VERSION 3.9)
-project(SuperFWGPUKernels CUDA CXX)
+project(SrgemmCudaKernels CUDA CXX)
 
-# RELEASE config by default:
-if (NOT CMAKE_BUILD_TYPE)
+string(TOUPPER "${CMAKE_BUILD_TYPE}" uppercase_CMAKE_BUILD_TYPE)
+
+# RELEASE config by default ifnone is provided:
+if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "RELEASE")
   set(BUILD_TYPE_INFERRED_RELEASE TRUE)
-endif ()
+elseif()
+  # otherwise, first convert build type string to uppercase, and then compare
+  if(NOT uppercase_CMAKE_BUILD_TYPE MATCHES "^(DEBUG|RELEASE|RELWITHDEBINFO)$")
+    message(FATAL_ERROR "Invalid value for CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
+  endif()
+  set(BUILD_TYPE_INFERRED_RELEASE FALSE)
+endif()
+
+# always dump compiler invocation commands to compile_commands.json
+set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 
 # Switches for testing, benchmarks or static lib builds
 option(FWGPU_TEST   "FWGPU_TEST"   ON)
@@ -13,10 +24,10 @@ option(FWGPU_BENCH  "FWGPU_BENCH"  ON)
 option(FWGPU_STATIC "FWGPU_STATIC" ON)
 
 # static or dynamic lib build targets
-if (FWGPU_STATIC)
+if(FWGPU_STATIC)
   set(FWGPU_LIB_NAME fwgpu_static)
   set(FWGPU_LIB_TYPE STATIC)
-else ()
+else()
   set(FWGPU_LIB_NAME fwgpu)
   set(FWGPU_LIB_TYPE SHARED)
 endif()
@@ -24,30 +35,33 @@ endif()
 # CUDA native compiler (nvcc) only supports upto C++14 for now
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Wall -fno-exceptions -DNDEBUG")
-set(CMAKE_CXX_FLAGS_DEBUG   "-O0 -Wall -Wextra -Wno-unused-parameter -fno-exceptions -DDEBUG -g")
+set(CMAKE_CXX_FLAGS_DEBUG   "-O0 -g3 -DDEBUG -Wall -Wextra -Wno-unused-parameter -fno-exceptions")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG -Wall -fno-exceptions")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g3 -DNDEBUG -Wall -fno-exceptions")
+# set(CMAKE_CXX_CLANG_TIDY clang-tidy -checks='bugprone-*,cert-*,clang-analyzer-core*,misc-*,performance-*')
 
 # CUDA build flags
 find_package(CUDA REQUIRED)
-if (CUDA_FOUND)
-  if (NOT CMAKE_CUDA_FLAGS)
+if(CUDA_FOUND)
+  if(NOT CMAKE_CUDA_FLAGS)
     cuda_select_nvcc_arch_flags(CUDA_ARCH_FLAGS Auto)
   endif()
-  set(CUDA_NVCC_FLAGS_RELEASE "-O3 --expt-relaxed-constexpr -DNDEBUG ${CMAKE_CUDA_FLAGS} ${CUDA_ARCH_FLAGS}")
-  set(CUDA_NVCC_FLAGS_DEBUG "-O0 --expt-relaxed-constexpr -DDEBUG -g -G ${CMAKE_CUDA_FLAGS} ${CUDA_ARCH_FLAGS}")
+  set(CUDA_NVCC_FLAGS_DEBUG "-O0 -g -G -DDEBUG --expt-relaxed-constexpr ${CMAKE_CUDA_FLAGS} ${CUDA_ARCH_FLAGS}")
+  set(CUDA_NVCC_FLAGS_RELEASE "-O3 -DNDEBUG --expt-relaxed-constexpr ${CMAKE_CUDA_FLAGS} ${CUDA_ARCH_FLAGS}")
+  set(CUDA_NVCC_FLAGS_RELWITHDEBINFO "-O3 -g -G -DNDEBUG --expt-relaxed-constexpr ${CMAKE_CUDA_FLAGS} ${CUDA_ARCH_FLAGS}")
 endif()
 
 # Source directory structure
 include_directories(${PROJECT_SOURCE_DIR}/include ${CUDA_INCLUDE_DIRS})
 
-if (FWGPU_TEST)
+if(FWGPU_TEST)
   enable_testing()
   add_subdirectory(test)
-endif ()
+endif()
 
-if (FWGPU_BENCH)
+if(FWGPU_BENCH)
   add_subdirectory(bench)
-endif ()
+endif()
 
 # fwgpu library configuration
 set(fwgpu_src
@@ -74,25 +88,19 @@ install(DIRECTORY ${FWGPU_LIB_NAME}/include DESTINATION include)
 
 message(STATUS "")
 message(STATUS "BUILD SUMMARY:")
+message(STATUS "  Build type           : ${uppercase_CMAKE_BUILD_TYPE}")
 message(STATUS "  CMAKE_GENERATOR      : ${CMAKE_GENERATOR}")
 message(STATUS "  C++ Compiler         : ${CMAKE_CXX_COMPILER}")
 message(STATUS "  C++ Compiler version : ${CMAKE_CXX_COMPILER_VERSION}")
 message(STATUS "  CUDA Compiler        : ${CMAKE_CUDA_COMPILER}")
 message(STATUS "  CUDA Compiler version: ${CMAKE_CUDA_COMPILER_VERSION}")
-message(STATUS "  Build type           : ${CMAKE_BUILD_TYPE}")
 message(STATUS "  Library name         : ${FWGPU_LIB_NAME}")
 message(STATUS "  Library type         : ${FWGPU_LIB_TYPE}")
 message(STATUS "  Build tests          : ${FWGPU_TEST}")
 message(STATUS "  Build benchmarks     : ${FWGPU_BENCH}")
 message(STATUS "  Found CUDA?          : ${CUDA_FOUND}")
-if("${CMAKE_BUILD_TYPE}" STREQUAL "RELEASE")
-  message(STATUS "  CXX flags            : ${CMAKE_CXX_FLAGS_RELEASE}")
-  message(STATUS "  CUDA flags           : ${CUDA_NVCC_FLAGS_RELEASE}")
-else()
-  message(STATUS "  CXX flags            : ${CMAKE_CXX_FLAGS_DEBUG}")
-  message(STATUS "  CUDA flags           : ${CUDA_NVCC_FLAGS_DEBUG}")
-endif()
+message(STATUS "  CXX flags            : ${CMAKE_CXX_FLAGS_${uppercase_CMAKE_BUILD_TYPE}}")
+message(STATUS "  CUDA flags           : ${CUDA_NVCC_FLAGS_${uppercase_CMAKE_BUILD_TYPE}}")
 if (BUILD_TYPE_INFERRED_RELEASE)
-  message(STATUS "WARNING: No build type provided, defaulted to RELEASE configuration.")
+  message(WARNING "No build type provided, defaulted to RELEASE configuration.")
 endif()
-message(STATUS "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,18 +1,16 @@
 cmake_minimum_required(VERSION 3.9)
 project(SrgemmCudaKernels CUDA CXX)
 
-string(TOUPPER "${CMAKE_BUILD_TYPE}" uppercase_CMAKE_BUILD_TYPE)
-
 # RELEASE config by default ifnone is provided:
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "RELEASE")
   set(BUILD_TYPE_INFERRED_RELEASE TRUE)
-elseif()
-  # otherwise, first convert build type string to uppercase, and then compare
-  if(NOT uppercase_CMAKE_BUILD_TYPE MATCHES "^(DEBUG|RELEASE|RELWITHDEBINFO)$")
-    message(FATAL_ERROR "Invalid value for CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
-  endif()
-  set(BUILD_TYPE_INFERRED_RELEASE FALSE)
+endif()
+
+# first convert build type string to uppercase, and then compare
+string(TOUPPER "${CMAKE_BUILD_TYPE}" uppercase_CMAKE_BUILD_TYPE)
+if(NOT uppercase_CMAKE_BUILD_TYPE MATCHES "^(DEBUG|RELEASE|RELWITHDEBINFO)$")
+  message(FATAL_ERROR "Invalid value for CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
 endif()
 
 # always dump compiler invocation commands to compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ if(NOT uppercase_CMAKE_BUILD_TYPE MATCHES "^(DEBUG|RELEASE|RELWITHDEBINFO)$")
 endif()
 
 # always dump compiler invocation commands to compile_commands.json
+# note that this does not include nvcc invocations >:(
 set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 
 # Switches for testing, benchmarks or static lib builds
@@ -47,6 +48,30 @@ if(CUDA_FOUND)
   set(CUDA_NVCC_FLAGS_DEBUG "-O0 -g -G -DDEBUG --expt-relaxed-constexpr ${CMAKE_CUDA_FLAGS} ${CUDA_ARCH_FLAGS}")
   set(CUDA_NVCC_FLAGS_RELEASE "-O3 -DNDEBUG --expt-relaxed-constexpr ${CMAKE_CUDA_FLAGS} ${CUDA_ARCH_FLAGS}")
   set(CUDA_NVCC_FLAGS_RELWITHDEBINFO "-O3 -g -G -DNDEBUG --expt-relaxed-constexpr ${CMAKE_CUDA_FLAGS} ${CUDA_ARCH_FLAGS}")
+endif()
+
+# the sub-modules update themselves with git, so find git
+find_package(Git QUIET)
+
+# make sure we have cutlass checked-out and is up-to-date
+if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
+  message(STATUS "Checking submodule version for thakkarV/cutlass")
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} submodule update --init ${PROJECT_SOURCE_DIR}/cutlass
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_SUBMOD_STDOUT OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_VARIABLE GIT_SUBMOD_STDERR ERROR_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE GIT_SUBMOD_RESULT
+  )
+  if(NOT GIT_SUBMOD_RESULT EQUAL "0")
+    message(FATAL_ERROR "git submodule update --init failed with ${GIT_SUBMOD_RESULT}, please checkout cutlass manually. Git stdout was ${GIT_SUBMOD_STDOUT}. Git stderr was ${GIT_SUBMOD_STDERR}.")
+  elseif(NOT ${GIT_SUBMOD_STDOUT} STREQUAL "")
+    message(STATUS ${GIT_SUBMOD_STDOUT})
+  endif()
+endif()
+
+if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/cutlass/include")
+  message(FATAL_ERROR "Cutlass submodule is not present and automatic checkout failed, please checkout cutlass manually.")
 endif()
 
 if(FWGPU_TEST)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,9 +51,6 @@ if(CUDA_FOUND)
   set(CUDA_NVCC_FLAGS_RELWITHDEBINFO "-O3 -g -G -DNDEBUG --expt-relaxed-constexpr ${CMAKE_CUDA_FLAGS} ${CUDA_ARCH_FLAGS}")
 endif()
 
-# Source directory structure
-include_directories(${PROJECT_SOURCE_DIR}/include ${CUDA_INCLUDE_DIRS})
-
 if(FWGPU_TEST)
   enable_testing()
   add_subdirectory(test)
@@ -79,8 +76,8 @@ target_link_libraries(
 )
 
 target_include_directories(${FWGPU_LIB_NAME} PUBLIC
-  ${PROJECT_SOURCE_DIR}
-  "${PROJECT_SOURCE_DIR}/cutlass/include"
+  ${PROJECT_SOURCE_DIR}/include
+  ${PROJECT_SOURCE_DIR}/cutlass/include
   ${CUDA_INCLUDE_DIRS})
 
 install(TARGETS ${FWGPU_LIB_NAME} LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -1,3 +1,24 @@
+# first make sure we have benchmark checked-out and its up-to-date
+if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
+  message(STATUS "Checking submodule version for google/benchmark")
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} submodule --quiet update --init ${PROJECT_SOURCE_DIR}/bench/benchmark
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_SUBMOD_STDOUT OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_VARIABLE GIT_SUBMOD_STDERR ERROR_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE GIT_SUBMOD_RESULT
+  )
+  if(NOT GIT_SUBMOD_RESULT EQUAL "0")
+    message(FATAL_ERROR "git submodule update --init failed with ${GIT_SUBMOD_RESULT}, please checkout benchmark manually. Git stdout was ${GIT_SUBMOD_STDOUT}. Git stderr was ${GIT_SUBMOD_STDERR}.")
+  elseif(NOT ${GIT_SUBMOD_STDOUT} STREQUAL "")
+    message(STATUS ${GIT_SUBMOD_STDOUT})
+  endif()
+endif()
+
+if(NOT EXISTS "${PROJECT_SOURCE_DIR}/bench/benchmark/include")
+  message(FATAL_ERROR "GTest submodule is not present and automatic checkout failed, please checkout benchmark manually.")
+endif()
+
 set(BENCHMARK_ENABLE_TESTING OFF)
 add_subdirectory(benchmark)
 

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -1,13 +1,9 @@
 set(BENCHMARK_ENABLE_TESTING OFF)
-
 add_subdirectory(benchmark)
-include_directories(${PROJECT_SOURCE_DIR}/include benchmark/include)
 
 # CPU benchmarks
-set(cpu_bench_src
-  cpu_bench.cpp
-)
-add_executable(cpu_bench ${cpu_bench_src})
+add_executable(cpu_bench cpu_bench.cpp)
+target_include_directories(cpu_bench PRIVATE benchmark/include)
 target_link_libraries(cpu_bench
   benchmark
   benchmark_main
@@ -16,10 +12,8 @@ target_link_libraries(cpu_bench
 )
 
 # GPU Benchmarks
-set(gpu_bench_src
-  gpu_bench.cu
-)
-CUDA_ADD_EXECUTABLE(gpu_bench ${gpu_bench_src})
+cuda_add_executable(gpu_bench gpu_bench.cu)
+target_include_directories(gpu_bench PRIVATE benchmark/include)
 target_link_libraries(gpu_bench
   benchmark
   benchmark_main

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,24 @@
+# first make sure we have gtest checked-out and its up-to-date
+if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
+  message(STATUS "Checking submodule version for google/googletest")
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} submodule update --init ${PROJECT_SOURCE_DIR}/test/gtest
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_SUBMOD_STDOUT OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_VARIABLE GIT_SUBMOD_STDERR ERROR_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE GIT_SUBMOD_RESULT
+  )
+  if(NOT GIT_SUBMOD_RESULT EQUAL "0")
+    message(FATAL_ERROR "git submodule update --init failed with ${GIT_SUBMOD_RESULT}, please checkout gtest manually. Git stdout was ${GIT_SUBMOD_STDOUT}. Git stderr was ${GIT_SUBMOD_STDERR}.")
+  elseif(NOT ${GIT_SUBMOD_STDOUT} STREQUAL "")
+    message(STATUS ${GIT_SUBMOD_STDOUT})
+  endif()
+endif()
+
+if(NOT EXISTS "${PROJECT_SOURCE_DIR}/test/gtest/googletest/include")
+  message(FATAL_ERROR "GTest submodule is not present and automatic checkout failed, please checkout gtest manually.")
+endif()
+
 add_subdirectory(gtest)
 
 ### Matrix tests

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,48 +1,27 @@
 add_subdirectory(gtest)
 
-include_directories(gtest/googletest/include)
-include_directories(${PROJECT_SOURCE_DIR}/include)
-
 ### Matrix tests
-set(Matrix_test_src
-  harness.cpp
-  Matrix_test.cpp
-)
-cuda_add_executable(Matrix_tests ${Matrix_test_src})
-target_link_libraries(Matrix_tests
-  gtest
-  ${FWGPU_LIB_NAME}
-)
+cuda_add_executable(Matrix_tests harness.cpp Matrix_test.cpp)
+target_include_directories(Matrix_tests PRIVATE gtest/googletest/include)
+target_link_libraries(Matrix_tests gtest ${FWGPU_LIB_NAME})
 add_test(
   NAME Matrix_tests
   COMMAND Matrix_tests
 )
 
 ### GEMM tests
-set(Gemm_test_src
-  harness.cpp
-  Gemm_test.cu
-)
-cuda_add_executable(Gemm_tests ${Gemm_test_src})
-target_link_libraries(Gemm_tests
-  gtest
-  ${FWGPU_LIB_NAME}
-)
+cuda_add_executable(Gemm_tests harness.cpp Gemm_test.cu)
+target_include_directories(Gemm_tests PRIVATE gtest/googletest/include)
+target_link_libraries(Gemm_tests gtest ${FWGPU_LIB_NAME})
 add_test(
   NAME Gemm_tests
   COMMAND Gemm_tests
 )
 
 ### SemiRing GEMM tests
-set(Srgemm_test_src
-  harness.cpp
-  Srgemm_test.cu
-)
-cuda_add_executable(Srgemm_tests ${Srgemm_test_src})
-target_link_libraries(Srgemm_tests
-  gtest
-  ${FWGPU_LIB_NAME}
-)
+cuda_add_executable(Srgemm_tests harness.cpp Srgemm_test.cu)
+target_include_directories(Srgemm_tests PRIVATE gtest/googletest/include)
+target_link_libraries(Srgemm_tests gtest ${FWGPU_LIB_NAME})
 add_test(
   NAME Srgemm_tests
   COMMAND Srgemm_tests


### PR DESCRIPTION
- add support for RelWithDebInfo builds
- add automatic checkout of submodules
- add automatic updates of submodules

- update target_include_directories() to use proper scoping of includes
- update build type detection to be case-insensitive
- update build type to reject non-supported build types in case they are explicitly specified
- update project name to be more faithful

- remove all global include_directories()
- remove some un-needed verbosity and make configurations simpler